### PR TITLE
fix: keep output file extensions to always be .js for all project…

### DIFF
--- a/src/modules/Bundler.js
+++ b/src/modules/Bundler.js
@@ -39,7 +39,7 @@ export default class Bundler {
         return {
             input: options.src,
             output: {
-                file: options.dest + (uglify? '.min' : '') + options.ext,
+                file: options.dest + (uglify? '.min.js' : '.js'),
                 format: options.format,
                 name: Util.camelCase(name),
                 interop: options.interop,


### PR DESCRIPTION
… file type

Output file extensions should be .js for .ts, .js, .jsx and other similar project file extensions

fix #2